### PR TITLE
Fix save interval reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ class Lokue extends EventEmitter {
 
   _initTimers () {
     this._tickItv = setInterval(this.tick.bind(this), this.opts.timeout_tick)
-    this._savetv = setInterval(this.save.bind(this), this.opts.timeout_save)
+    this._saveItv = setInterval(this.save.bind(this), this.opts.timeout_save)
   }
 
   _initDB () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lokue",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": false,
   "description": "LokiJS Task Queue",
   "author": {


### PR DESCRIPTION
This PR fixes save interval reference for the `stop` method https://github.com/bitfinexcom/lokue/blob/master/index.js#L63

---

With the wrong interval reference, it can't be stopped in time correctly, and after getting a stop of workers it continues to write JSON file
